### PR TITLE
LUGG-776 Make transcript field collapsible

### DIFF
--- a/js/luggage_video.js
+++ b/js/luggage_video.js
@@ -1,0 +1,17 @@
+/*
+ * Javascript that makes transcripts collapsible
+ */
+(function($) {
+    Drupal.behaviors.luggage_video = {
+        attach: function (context, settings) {
+            $('body', context).once('transcript_hide', function () {
+                $('.field-name-field-video-transcript .field-items').css('display', 'none');
+                $('.field-name-field-video-transcript .field-label').append('<em>(Click to expand)</em>');
+                $('.field-name-field-video-transcript .field-label').wrapInner('<a href="" onclick="return false;"></a>');
+                $('.field-name-field-video-transcript .field-label').click(function () {
+                    $(this).parent().children('.field-items').slideToggle('slow');
+                });
+            });
+        }
+    }
+})(jQuery);

--- a/luggage_video.css
+++ b/luggage_video.css
@@ -15,13 +15,3 @@
   height: 100%;
 }
 /* End responsive video */
-
-/* Hide transcript from sighted users */
-.field-name-field-video-transcript {
-  position: absolute;
-  left: -10000px;
-  top: auto;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-}

--- a/luggage_video.module
+++ b/luggage_video.module
@@ -8,4 +8,5 @@ include_once 'luggage_video.features.inc';
 
 function luggage_video_preprocess_node(&$vars) {
   drupal_add_css(drupal_get_path('module', 'luggage_video') . '/luggage_video.css');
+  drupal_add_js(drupal_get_path('module', 'luggage_video') . '/js/luggage_video.js');
 }


### PR DESCRIPTION
Right now, the transcript field is styled to appear off the page. This may be useful for people with screen readers, but anyone who is hearing impaired will not be able to make use of the transcript field. This pull request seeks to make the transcript field collapsible so that hearing impaired individuals can still make use of it.
## Testing
- Pull down my changes
- Be sure that your features aren't locked
- Run drush feature revert all and drush cc all
- Create a video node with something in the transcript/alternate URL field
- Create an event node with something in the transcript/alternate URL field
- Go to the full node view of the event/video and verify that the transcript field is visible
- Is the field collapsed? Does it expand when clicked on? When you click on it, do you stay on the same page?
## Improvements:

Maybe check to be sure that field-name-field-video-transcript exists in the drupal_add_js()?
Feels like the jQuery part could be condensed a bit.
